### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -58,6 +58,8 @@ jobs:
   # Optional: Add a job to comment on PR with results
   comment-on-pr:
     name: Comment on PR
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: sonarcloud
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Potential fix for [https://github.com/GiveProtocol/Duration-Give/security/code-scanning/62](https://github.com/GiveProtocol/Duration-Give/security/code-scanning/62)

To fix the problem, add a `permissions` block to the `comment-on-pr` job in `.github/workflows/sonarcloud.yml`. This block should grant only the `pull-requests: write` permission, which is the minimum required for the job to comment on pull requests. No other permissions are needed for this job. The change should be made directly under the `name: Comment on PR` line (line 60), before `runs-on`. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
