### PR TITLE
Potential fix for code scanning alert no. 60: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/new-code-analysis.yml
+++ b/.github/workflows/new-code-analysis.yml
@@ -1,4 +1,6 @@
 name: New Code Analysis
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/GiveProtocol/Duration-Give/security/code-scanning/60](https://github.com/GiveProtocol/Duration-Give/security/code-scanning/60)

To fix the problem, add a `permissions` block to the workflow or to the specific job(s) that require it. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. If any step requires additional permissions (such as commenting on pull requests), you can add those as needed (e.g., `pull-requests: write`). In this case, since the workflow does not appear to need write access, adding `permissions: contents: read` at the workflow level (top of the file, after `name:` and before `on:`) is the best way to fix the problem without changing existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
