### PR TITLE
Potential fix for code scanning alert no. 61: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -28,6 +28,8 @@ env:
 jobs:
   code-quality:
     name: Code Quality Checks
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     


### PR DESCRIPTION
Potential fix for [https://github.com/GiveProtocol/Duration-Give/security/code-scanning/61](https://github.com/GiveProtocol/Duration-Give/security/code-scanning/61)

To fix the problem, add a `permissions` block to the `code-quality` job (or at the workflow root) specifying the minimal required permissions. Since the job only needs to read repository contents (for checkout and analysis), set `contents: read`. This should be added as the first key under the `code-quality` job (after `name`, before `runs-on`). No other changes are needed, as the rest of the job does not require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
