### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,6 +14,8 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     if: false  # Set to true to re-enable
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/GiveProtocol/Duration-Give/security/code-scanning/64](https://github.com/GiveProtocol/Duration-Give/security/code-scanning/64)

To fix the problem, you should add a `permissions` block to the `sonarcloud` job, specifying the minimal required permissions. For SonarCloud analysis, the job typically only needs read access to repository contents (`contents: read`). This change should be made within the `sonarcloud` job definition, ideally just after the `runs-on` and `if` keys, before the `steps` block. No additional imports or definitions are needed; this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
